### PR TITLE
[RFR] Respect Cache-Control and Vary headers from results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-#sudo: false
+sudo: false
 language: node_js
 node_js:
   - "0.11"

--- a/lib/batchRequestor.js
+++ b/lib/batchRequestor.js
@@ -73,11 +73,12 @@ module.exports = function (requestor) {
 
       ++totalResults;
 
-      for (headerName in results[name].headers) {
-        header = results[name].headers[headerName];
+      for (i in results[name].headers) {
+        header = results[name].headers[i];
+        headerName = header.name.toLowerCase();
 
-        if ('cache-control' === headerName.toLowerCase()) {
-          parsedCacheControl = parseCacheControl(header);
+        if ('cache-control' === headerName) {
+          parsedCacheControl = parseCacheControl(header.value);
 
           if (parsedCacheControl['no-cache']) {
             noCache = true;
@@ -104,8 +105,8 @@ module.exports = function (requestor) {
           ++totalCacheControl;
         }
 
-        if ('vary' === headerName.toLowerCase()) {
-          header.split(',').forEach(function (vary) {
+        if ('vary' === headerName) {
+          header.value.split(',').forEach(function (vary) {
             vary = vary.trim();
             if (-1 === varies.indexOf(vary)) {
               varies.push(vary);

--- a/lib/batchRequestor.js
+++ b/lib/batchRequestor.js
@@ -1,46 +1,11 @@
 'use strict';
 
+var headerExtractor = require('./headerExtractor');
+
 module.exports = function (requestor) {
-  /* Extracted from https://github.com/hapijs/wreck library */
-  function parseCacheControl(field) {
-    /*
-      Cache-Control   = 1#cache-directive
-      cache-directive = token [ "=" ( token / quoted-string ) ]
-      token           = [^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+
-      quoted-string   = "(?:[^"\\]|\\.)*"
-    */
-
-    //                             1: directive                                        =   2: token                                              3: quoted-string
-    var regex = /(?:^|(?:\s*\,\s*))([^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+)(?:\=(?:([^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+)|(?:\"((?:[^"\\]|\\.)*)\")))?/g;
-
-    var header = {};
-    var err = field.replace(regex, function ($0, $1, $2, $3) {
-      var value = $2 || $3;
-      header[$1] = value ? value.toLowerCase() : true;
-
-      return '';
-    });
-
-    var integerFieldValue;
-    for (var integerField in ['max-age', 's-maxage']) {
-      if (integerField in header) {
-        try {
-          integerFieldValue = parseInt(header[integerField], 10);
-          if (isNaN(integerFieldValue)) {
-            return null;
-          }
-
-          header[integerField] = integerFieldValue;
-        }
-        catch (err) { }
-      }
-    }
-
-    return (err ? null : header);
-  };
-
   return function* batchRequestor(requests, baseUrl, headers) {
     var results = {},
+        resultsHeaders = {},
         requestsThunks = [],
         i = 0,
         name;
@@ -51,99 +16,20 @@ module.exports = function (requestor) {
       i++;
     }
 
-    var resultsArray = yield requestsThunks,
-        responseHeaders = {},
-        header,
-        headerName,
-        totalResults = 0,
-        totalCacheControl = 0,
-        maxMaxAge = 0,
-        maxSharedMaxAge = 0,
-        privateCache = false,
-        publicCache = false,
-        noCache = false,
-        varies = [],
-        parsedCacheControl;
+    var resultsArray = yield requestsThunks, totalResults = 0;
 
     for (name in results) {
       results[name] = resultsArray[results[name]];
-      if (!results[name] || noCache) {
+      if (!results[name]) {
         continue;
       }
 
       ++totalResults;
 
-      for (i in results[name].headers) {
-        header = results[name].headers[i];
-        headerName = header.name.toLowerCase();
-
-        if ('cache-control' === headerName) {
-          parsedCacheControl = parseCacheControl(header.value);
-
-          if (parsedCacheControl['no-cache']) {
-            noCache = true;
-
-            break;
-          }
-
-          if (parsedCacheControl.private) {
-            privateCache = true;
-          }
-
-          if (parsedCacheControl.public) {
-            publicCache = true;
-          }
-
-          if (parsedCacheControl['max-age'] && parsedCacheControl['max-age'] > maxMaxAge) {
-            maxMaxAge = parsedCacheControl['max-age'];
-          }
-
-          if (parsedCacheControl['s-maxage'] && parsedCacheControl['s-maxage'] > maxSharedMaxAge) {
-            maxSharedMaxAge = parsedCacheControl['s-maxage'];
-          }
-
-          ++totalCacheControl;
-        }
-
-        if ('vary' === headerName) {
-          header.value.split(',').forEach(function (vary) {
-            vary = vary.trim();
-            if (-1 === varies.indexOf(vary)) {
-              varies.push(vary);
-            }
-          })
-        }
-      }
+      resultsHeaders[name] = headerExtractor.extract(results[name].headers);
     }
 
-    if (noCache) {
-      responseHeaders['Cache-Control'] = 'no-cache';
-
-    } else if (totalCacheControl === totalResults) {
-      if (privateCache || publicCache || maxMaxAge || maxSharedMaxAge) {
-        var cacheControl = [];
-
-        if (privateCache) {
-          cacheControl.push('private');
-        } else if (publicCache) {
-          cacheControl.push('public');
-        }
-
-        if (maxMaxAge) {
-          cacheControl.push('max-age=' + maxMaxAge);
-        }
-
-        if (maxSharedMaxAge) {
-          cacheControl.push('s-maxage=' + maxSharedMaxAge);
-        }
-
-        responseHeaders['Cache-Control'] = cacheControl.join(", ");
-      }
-
-      if (varies.length) {
-        responseHeaders.Vary = varies.join(", ");
-      }
-    }
+    var responseHeaders = headerExtractor.compute(resultsHeaders, totalResults);
 
     return { body: results, headers: responseHeaders };
   };

--- a/lib/batchRequestor.js
+++ b/lib/batchRequestor.js
@@ -1,23 +1,149 @@
 'use strict';
 
 module.exports = function (requestor) {
+  /* Extracted from https://github.com/hapijs/wreck library */
+  function parseCacheControl(field) {
+    /*
+      Cache-Control   = 1#cache-directive
+      cache-directive = token [ "=" ( token / quoted-string ) ]
+      token           = [^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+
+      quoted-string   = "(?:[^"\\]|\\.)*"
+    */
+
+    //                             1: directive                                        =   2: token                                              3: quoted-string
+    var regex = /(?:^|(?:\s*\,\s*))([^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+)(?:\=(?:([^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+)|(?:\"((?:[^"\\]|\\.)*)\")))?/g;
+
+    var header = {};
+    var err = field.replace(regex, function ($0, $1, $2, $3) {
+      var value = $2 || $3;
+      header[$1] = value ? value.toLowerCase() : true;
+
+      return '';
+    });
+
+    var integerFieldValue;
+    for (var integerField in ['max-age', 's-maxage']) {
+      if (integerField in header) {
+        try {
+          integerFieldValue = parseInt(header[integerField], 10);
+          if (isNaN(integerFieldValue)) {
+            return null;
+          }
+
+          header[integerField] = integerFieldValue;
+        }
+        catch (err) { }
+      }
+    }
+
+    return (err ? null : header);
+  };
 
   return function* batchRequestor(requests, baseUrl, headers) {
-    var results = {};
-    var requestsThunks = [];
-    var i = 0, name;
+    var results = {},
+        requestsThunks = [],
+        i = 0,
+        name;
+
     for (name in requests) {
       requestsThunks[i] = requestor.get(baseUrl + requests[name], headers);
       results[name] = i;
       i++;
     }
 
-    var resultsArray = yield requestsThunks;
+    var resultsArray = yield requestsThunks,
+        responseHeaders = {},
+        header,
+        headerName,
+        totalResults = 0,
+        totalCacheControl = 0,
+        maxMaxAge = 0,
+        maxSharedMaxAge = 0,
+        privateCache = false,
+        publicCache = false,
+        noCache = false,
+        varies = [],
+        parsedCacheControl;
 
     for (name in results) {
       results[name] = resultsArray[results[name]];
+      if (!results[name] || noCache) {
+        continue;
+      }
+
+      ++totalResults;
+
+      for (headerName in results[name].headers) {
+        header = results[name].headers[headerName];
+
+        if ('cache-control' === headerName.toLowerCase()) {
+          parsedCacheControl = parseCacheControl(header);
+
+          if (parsedCacheControl['no-cache']) {
+            noCache = true;
+
+            break;
+          }
+
+          if (parsedCacheControl.private) {
+            privateCache = true;
+          }
+
+          if (parsedCacheControl.public) {
+            publicCache = true;
+          }
+
+          if (parsedCacheControl['max-age'] && parsedCacheControl['max-age'] > maxMaxAge) {
+            maxMaxAge = parsedCacheControl['max-age'];
+          }
+
+          if (parsedCacheControl['s-maxage'] && parsedCacheControl['s-maxage'] > maxSharedMaxAge) {
+            maxSharedMaxAge = parsedCacheControl['s-maxage'];
+          }
+
+          ++totalCacheControl;
+        }
+
+        if ('vary' === headerName.toLowerCase()) {
+          header.split(',').forEach(function (vary) {
+            vary = vary.trim();
+            if (-1 === varies.indexOf(vary)) {
+              varies.push(vary);
+            }
+          })
+        }
+      }
     }
 
-    return results;
+    if (noCache) {
+      responseHeaders['Cache-Control'] = 'no-cache';
+
+    } else if (totalCacheControl === totalResults) {
+      if (privateCache || publicCache || maxMaxAge || maxSharedMaxAge) {
+        var cacheControl = [];
+
+        if (privateCache) {
+          cacheControl.push('private');
+        } else if (publicCache) {
+          cacheControl.push('public');
+        }
+
+        if (maxMaxAge) {
+          cacheControl.push('max-age=' + maxMaxAge);
+        }
+
+        if (maxSharedMaxAge) {
+          cacheControl.push('s-maxage=' + maxSharedMaxAge);
+        }
+
+        responseHeaders['Cache-Control'] = cacheControl.join(", ");
+      }
+
+      if (varies.length) {
+        responseHeaders.Vary = varies.join(", ");
+      }
+    }
+
+    return { body: results, headers: responseHeaders };
   };
 };

--- a/lib/headerExtractor.js
+++ b/lib/headerExtractor.js
@@ -1,0 +1,182 @@
+'use strict';
+
+module.exports = {
+  /* Extracted from https://github.com/hapijs/wreck library */
+  _parseCacheControl: function (field) {
+    /*
+      Cache-Control   = 1#cache-directive
+      cache-directive = token [ "=" ( token / quoted-string ) ]
+      token           = [^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+
+      quoted-string   = "(?:[^"\\]|\\.)*"
+    */
+
+    //                             1: directive                                        =   2: token                                              3: quoted-string
+    var regex = /(?:^|(?:\s*\,\s*))([^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+)(?:\=(?:([^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+)|(?:\"((?:[^"\\]|\\.)*)\")))?/g;
+
+    var header = {};
+    var err = field.replace(regex, function ($0, $1, $2, $3) {
+      var value = $2 || $3;
+      header[$1] = value ? value.toLowerCase() : true;
+
+      return '';
+    });
+
+    var integerFieldValue;
+    for (var integerField in ['max-age', 's-maxage']) {
+      if (integerField in header) {
+        try {
+          integerFieldValue = parseInt(header[integerField], 10);
+          if (isNaN(integerFieldValue)) {
+            return null;
+          }
+
+          header[integerField] = integerFieldValue;
+        }
+        catch (err) { }
+      }
+    }
+
+    return (err ? null : header);
+  },
+
+  extract: function (headers) {
+    var header,
+        cacheControl = false,
+        varies = [];
+
+    for (var i in headers) {
+      header = headers[i];
+
+      switch (header.name.toLowerCase()) {
+        case 'cache-control':
+          var parsedCacheControl = this._parseCacheControl(header.value);
+
+          cacheControl = {
+            maxAge: 0,
+            sharedMaxAge: 0,
+            'private': false,
+            'public': false,
+            noCache: false
+          };
+
+          if ('no-cache' in parsedCacheControl) {
+            cacheControl.noCache = true;
+
+            break;
+          }
+
+          if ('private' in parsedCacheControl) {
+            cacheControl['private'] = true;
+          }
+
+          if ('public' in parsedCacheControl) {
+            cacheControl['public'] = true;
+          }
+
+          if ('max-age' in parsedCacheControl) {
+            cacheControl.maxAge = parsedCacheControl['max-age'];
+          }
+
+          if ('s-maxage' in parsedCacheControl) {
+            cacheControl.sharedMaxAge = parsedCacheControl['s-maxage'];
+          }
+
+          break;
+
+        case 'vary':
+          header.value.split(',').forEach(function (vary) {
+            varies.push(vary.trim());
+          });
+        break;
+      }
+    }
+
+    return {
+      cacheControl: cacheControl,
+      varies: varies
+    };
+  },
+
+  compute: function (headers, totalResults) {
+    var totalCacheControl = 0, name;
+
+    for (name in headers) {
+      if (false === headers[name].cacheControl) {
+        continue;
+      }
+
+      // if one of header contain no-cache so force to no-cache
+      if (headers[name].cacheControl.noCache) {
+        return { 'Cache-Control': 'no-cache' };
+      }
+
+      ++totalCacheControl;
+    }
+
+    if (totalCacheControl !== totalResults) {
+      return {};
+    }
+
+    var responseHeaders = {},
+        privateCache = false,
+        publicCache = false,
+        maxMaxAge = 0,
+        maxSharedMaxAge = 0,
+        currentCacheControl = {},
+        currentVaries = [],
+        varies = [];
+
+    for (name in headers) {
+      currentCacheControl = headers[name].cacheControl;
+      currentVaries = headers[name].varies;
+
+      if (currentCacheControl.maxAge > maxMaxAge) {
+        maxMaxAge = currentCacheControl.maxAge;
+      }
+
+      if (currentCacheControl.sharedMaxAge > maxSharedMaxAge) {
+        maxSharedMaxAge = currentCacheControl.sharedMaxAge;
+      }
+
+      if (currentCacheControl['private']) {
+        privateCache = true;
+      }
+
+      if (currentCacheControl['public']) {
+        publicCache = true;
+      }
+
+      for (var i in currentVaries) {
+        if (-1 === varies.indexOf(currentVaries[i])) {
+          varies.push(currentVaries[i]);
+        }
+      }
+    }
+
+    if (privateCache || publicCache || maxMaxAge || maxSharedMaxAge) {
+      var cacheControl = [];
+
+      if (privateCache) {
+        cacheControl.push('private');
+      } else if (publicCache) {
+        cacheControl.push('public');
+      }
+
+      if (maxMaxAge) {
+        cacheControl.push('max-age=' + maxMaxAge);
+      }
+
+      if (maxSharedMaxAge) {
+        cacheControl.push('s-maxage=' + maxSharedMaxAge);
+      }
+
+      responseHeaders['Cache-Control'] = cacheControl.join(", ");
+    }
+
+    if (varies.length) {
+      responseHeaders.Vary = varies.join(", ");
+    }
+
+    return responseHeaders;
+  }
+}

--- a/lib/multiFetch.js
+++ b/lib/multiFetch.js
@@ -21,6 +21,11 @@ module.exports = function (options) {
 
     var baseUrl = options.absolute ? this.headers.host : this.headers.host + this.req._parsedUrl.pathname;
 
-    this.body = yield batchRequestor(data, baseUrl, this.headers);
+    var result = yield batchRequestor(data, baseUrl, this.headers);
+
+    this.body = result.body;
+    for (var name in result.headers) {
+      this.set(name, result.headers[name]);
+    }
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-multifetch",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A Koa.js middleware for performing internal batch requests",
   "main": "lib/multiFetch.js",
   "directories": {

--- a/test/batchRequestor.js
+++ b/test/batchRequestor.js
@@ -10,7 +10,7 @@ describe('batchRequestor', function () {
         this.getCall++;
         this.headers = headers;
 
-        return 'result for ' + url;
+        return { code: 200, body: 'result for ' + url, headers: {} };
       },
       headers: null,
       getCall: 0
@@ -19,10 +19,10 @@ describe('batchRequestor', function () {
   });
 
   it('should return result for all given url', co(function* () {
-
-    assert.deepEqual(yield batchRequestor({resource1: '/resource1/5', resource2: '/resource2'}, '/host/api'), {
-      resource1: 'result for /host/api/resource1/5',
-      resource2: 'result for /host/api/resource2'
+    var result = yield batchRequestor({resource1: '/resource1/5', resource2: '/resource2'}, '/host/api');
+    assert.deepEqual(result.body, {
+      resource1: { code: 200, body: 'result for /host/api/resource1/5', headers: {} },
+      resource2: { code: 200, body: 'result for /host/api/resource2', headers: {} }
     });
   }));
 
@@ -43,5 +43,73 @@ describe('batchRequestor', function () {
     assert.deepEqual(mockRequestor.headers, expectedHeaders);
 
     assert.equal(mockRequestor.getCall, 2);
+  }));
+
+  it('should include Cache-Control and Vary headers extracted from results', co(function* () {
+    var responseHeaders = {};
+    mockRequestor = {
+      get: function* (url, headers) {
+        responseHeaders = {};
+        if ('/api/1' === url) {
+          responseHeaders = {
+            'Cache-Control': 'public, max-age=300',
+            'Vary': 'Cookie'
+          };
+        }
+        if ('/api/2' === url) {
+          responseHeaders = {
+            'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+            'Vary': 'User-Agent'
+          };
+        }
+
+        return { code: 200, body: 'result for ' + url, headers: responseHeaders };
+      }
+    }
+    batchRequestor = require('../lib/batchRequestor')(mockRequestor);
+
+    var results = yield batchRequestor({resource1: 'api/1', resource2: 'api/2'}, '/');
+    assert.deepEqual(results.headers, { 'Cache-Control': 'public, max-age=3600, s-maxage=3600', Vary: 'Cookie, User-Agent' });
+  }));
+
+  it('should not include Cache-Control and Vary header if at least one of results omit them', co(function* () {
+    var responseHeaders = {};
+    mockRequestor = {
+      get: function* (url, headers) {
+        responseHeaders = {};
+        if ('/api/1' === url) {
+          responseHeaders = {
+            'Cache-Control': 'public, max-age=300',
+            'Vary': 'Cookie'
+          };
+        }
+
+        return { code: 200, body: 'result for ' + url, headers: responseHeaders };
+      }
+    }
+    batchRequestor = require('../lib/batchRequestor')(mockRequestor);
+
+    results = yield batchRequestor({ resource1: 'api/1', resource2: 'api/2' }, '/');
+    assert.deepEqual(results.headers, {});
+  }));
+
+  it('should set Cache-Control if at least one of results have no-cache directive', co(function* () {
+    var responseHeaders = {};
+    mockRequestor = {
+      get: function* (url, headers) {
+        responseHeaders = {};
+        if ('/api/1' === url) {
+          responseHeaders = {
+            'Cache-Control': 'no-cache',
+          };
+        }
+
+        return { code: 200, body: 'result for ' + url, headers: responseHeaders };
+      }
+    }
+    batchRequestor = require('../lib/batchRequestor')(mockRequestor);
+
+    results = yield batchRequestor({ resource1: 'api/1', resource2: 'api/2' }, '/');
+    assert.deepEqual(results.headers, { 'Cache-Control': 'no-cache' });
   }));
 });

--- a/test/batchRequestor.js
+++ b/test/batchRequestor.js
@@ -51,16 +51,16 @@ describe('batchRequestor', function () {
       get: function* (url, headers) {
         responseHeaders = {};
         if ('/api/1' === url) {
-          responseHeaders = {
-            'Cache-Control': 'public, max-age=300',
-            'Vary': 'Cookie'
-          };
+          responseHeaders = [
+            { name: 'Cache-Control', value: 'public, max-age=300' },
+            { name: 'Vary', value: 'Cookie' }
+          ];
         }
         if ('/api/2' === url) {
-          responseHeaders = {
-            'Cache-Control': 'public, max-age=3600, s-maxage=3600',
-            'Vary': 'User-Agent'
-          };
+          responseHeaders = [
+            { name: 'Cache-Control', value: 'public, max-age=3600, s-maxage=3600' },
+            { name: 'Vary', value: 'User-Agent' }
+          ];
         }
 
         return { code: 200, body: 'result for ' + url, headers: responseHeaders };
@@ -78,10 +78,10 @@ describe('batchRequestor', function () {
       get: function* (url, headers) {
         responseHeaders = {};
         if ('/api/1' === url) {
-          responseHeaders = {
-            'Cache-Control': 'public, max-age=300',
-            'Vary': 'Cookie'
-          };
+          responseHeaders = [
+            { name: 'Cache-Control', value: 'public, max-age=300' },
+            { name: 'Vary', value: 'Cookie' }
+          ];
         }
 
         return { code: 200, body: 'result for ' + url, headers: responseHeaders };
@@ -99,9 +99,9 @@ describe('batchRequestor', function () {
       get: function* (url, headers) {
         responseHeaders = {};
         if ('/api/1' === url) {
-          responseHeaders = {
-            'Cache-Control': 'no-cache',
-          };
+          responseHeaders = [
+            { name: 'Cache-Control', value: 'no-cache' }
+          ];
         }
 
         return { code: 200, body: 'result for ' + url, headers: responseHeaders };


### PR DESCRIPTION
If one of results have `Cache-Control` header and it set to `no-cache` so response will set the `Cache-Control` response header to `no-cache`.

If all results contain a `Cache-Control` header so response will contain the higher value of `max-age` and/or `s-maxage`. `private` will be set if one results define it.